### PR TITLE
Support alternative languages

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,6 @@ activate :prismic do |f|
   f.api_url = 'https://testrepositorymiddleman.prismic.io/api'
   f.release = 'master'
   f.link_resolver = ->(link) { binding.pry; "#{link.type.pluralize}/#{link.slug}"}
-  f.custom_queries = { test: [Prismic::Predicates::at('document.type', 'product')] }
 end
 ```
 

--- a/lib/middleman-prismic.rb
+++ b/lib/middleman-prismic.rb
@@ -14,7 +14,7 @@ module Middleman
       option :release, 'master', 'Content release'
       option :access_token, nil, 'Access token (optional)'
       option :link_resolver, ->(_link) {"/"}, 'The link resolver'
-      option :custom_queries, {}, 'Custom queries'
+      option :locales, {}, 'Alternative languages'
 
       def initialize(app, options_hash={}, &block)
         super

--- a/lib/middleman-prismic.rb
+++ b/lib/middleman-prismic.rb
@@ -14,7 +14,7 @@ module Middleman
       option :release, 'master', 'Content release'
       option :access_token, nil, 'Access token (optional)'
       option :link_resolver, ->(_link) {"/"}, 'The link resolver'
-      option :locales, {}, 'Alternative languages'
+      option :locales, {}, 'Supported languages'
 
       def initialize(app, options_hash={}, &block)
         super

--- a/lib/middleman-prismic/commands/prismic.rb
+++ b/lib/middleman-prismic/commands/prismic.rb
@@ -33,7 +33,6 @@ module Middleman
         create_directories
         output_documents_by_locale
         output_references
-        output_custom_queries
       end
 
       private

--- a/spec/middleman-prismic/commands/prismic_spec.rb
+++ b/spec/middleman-prismic/commands/prismic_spec.rb
@@ -44,34 +44,6 @@ describe Middleman::Cli::Prismic do
       expect(File).to exist(reference_path)
     end
 
-    it "outputs any custom queries" do
-      prismic_query = double("prismic_query")
-      stub_options(
-        custom_queries: {
-          test: [prismic_query]
-        }
-      )
-      document = double("document", id: "thing", to_yaml: "yaml")
-      response = double(
-        "response",
-        group_by: { "foo" => [document] },
-        each: [document],
-        total_pages: 1,
-      )
-      api_form = stub_prismic_api(response)
-      allow(api_form).to receive(:query).and_return(api_form)
-
-      custom_path = File.join(described_class::DATA_DIR, "custom_test")
-      expect(File).not_to exist(custom_path)
-
-      described_class.new.prismic
-
-      expect(File).to exist(custom_path)
-      expect(api_form).
-        to have_received(:query).
-          with(prismic_query)
-    end
-
     it "downloads via prismic ref" do
       stub_options
       response = double("response", group_by: [], total_pages: 1)
@@ -92,7 +64,6 @@ describe Middleman::Cli::Prismic do
         access_token: nil,
         api_url: "http://example.com",
         release: "release",
-        custom_queries: [],
       }.merge(hash)
     )
     allow(Middleman::Prismic).to receive(:options).and_return(options)


### PR DESCRIPTION
### Description
This PR updates the `middleman-prismic` gem to support the usage of locales. It does this by iterating over the languages provided in the config, creating directories for them, then querying the content for all the document types in that language.

### Usage
```rb
activate :prismic do |f|
  f.api_url = config[:prismic_url]
  f.release = 'master'
  f.access_token = ENV["PRISMIC_ACCESS_TOKEN"]
  f.locales = ['en-us', 'es-es']
end
```

### Screenshots
<img width="244" alt="Screen Shot 2022-03-14 at 9 32 39 PM" src="https://user-images.githubusercontent.com/2153230/158288302-4091c778-4b0c-42ad-8b3d-8f5d46518e69.png">

